### PR TITLE
Fix: Remove leftovers in manifest from Kerberos GUI removal

### DIFF
--- a/usr/src/pkg/manifests/system-security-kerberos-5.mf
+++ b/usr/src/pkg/manifests/system-security-kerberos-5.mf
@@ -42,7 +42,6 @@ dir path=lib/svc/manifest/network/security group=sys
 dir path=usr group=sys
 dir path=usr/lib
 dir path=usr/lib/krb5
-dir path=usr/lib/krb5/ListResourceBundle
 dir path=usr/lib/security
 dir path=usr/sbin
 dir path=usr/share


### PR DESCRIPTION
## Builds were giving the following error:

.....
==== Validating manifests against proto area ====

Entries present in manifests but not proto area:
    dir group=bin mode=0755 owner=root path=usr/lib/krb5/ListResourceBundle
## .....

This fix completes the removal of the Kerberos GUI was started in fix #114 and the above error goes away.

Testing: Incremental build of illumos-core (full nightly was made the same day before that).
