### PR TITLE
fixes #134 cstyle: check binary op continuations

### DIFF
--- a/usr/src/tools/scripts/cstyle.pl
+++ b/usr/src/tools/scripts/cstyle.pl
@@ -19,7 +19,7 @@
 #
 # CDDL HEADER END
 #
-#
+# Copyright 2014 Ryan Zezeski
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
@@ -539,8 +539,18 @@ line: while (<$filehandle>) {
 	if (/\s[,;]/ && !/^[\t]+;$/ && !/^\s*for \([^;]*; ;[^;]*\)/) {
 		err("comma or semicolon preceded by blank");
 	}
-	if (/^\s*(&&|\|\|)/) {
-		err("improper boolean continuation");
+	# binary and assignment operators must not start a
+	# continuation line
+	#
+	# `[|<>\/^%=]` - covers |, ||, |=, <, <=, <<, <<=, >, >=, >>, =, ==
+	#                >>=, /, /=, ^, ^=, %, %=, =, ==
+	#
+	# `[-*+&] ` - covers `- `, `* `, `+ `, `& `
+	#
+	# `[-+*&!]=` - covers -=, +=, *=, &=, !=
+	#
+	if (/^\s*([|<>\/^%=]|[-*+&] |[-+*&!]=|&&)/) {
+		err("binary or assignment operator at start of continuation");
 	}
 	if (/\S   *(&&|\|\|)/ || /(&&|\|\|)   *\S/) {
 		err("more than one space around boolean operator");


### PR DESCRIPTION
Fixes #134.

I tested this by running against `usr/src/uts/i86pc/` and verifying
that reports of `binary operator at start of continuation` were not
false alarms. E.g., if a continuation starts with a dereference like
`*pointer` then it should not be flagged. It turns out there are
plenty of areas in UTS that violate this particular cstyle rule.

```
find usr/src/uts/i86pc/ -name "*.c" | xargs -L1 perl usr/src/tools/scripts/cstyle.pl -cpv | grep 'binary op' -C2
```
