### PR TITLE
fixes #151 Remove the usual |%WHOANDWHERE%| error message from the build

### DIFF
--- a/usr/src/tools/scripts/nightly.sh
+++ b/usr/src/tools/scripts/nightly.sh
@@ -257,7 +257,6 @@ function build {
 			| egrep -v 'chars, width' \
 			| egrep -v "symbol (\`|')timezone' has differing types:" \
 			| egrep -v 'PSTAMP' \
-			| egrep -v '|%WHOANDWHERE%|' \
 			| egrep -v '^Manifying' \
 			| egrep -v 'Ignoring unknown host' \
 			| egrep -v 'Processing method:' \


### PR DESCRIPTION
I'll continue experimenting with the rest of the regular expressions from this issue as I learn more.
Deleting only the buggy one for now.